### PR TITLE
Correct small typo `s/upstatment/upstatement`

### DIFF
--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -3,4 +3,5 @@ title: "About me"
 template: "page"
 ---
 
-I am currently a Lead Engineer at [Upstatment](http://upstatement.com) in Boston, MA.
+I am currently a Lead Engineer at [Upstatement](http://upstatement.com) in
+Boston, MA.


### PR DESCRIPTION
## Description

This work addresses the typo `s/upstatment/upstatement` :) 

## Related Issues

There is no related issue for this change as it's a typo vs something more serious.
